### PR TITLE
Stop breaking out of the read loop on multi-part message

### DIFF
--- a/client.go
+++ b/client.go
@@ -221,10 +221,6 @@ loop:
 			}
 
 			cb(*conn)
-
-			if msg.Header.Flags&unix.NLM_F_MULTI > 0 {
-				break loop
-			}
 		}
 	}
 	return nil


### PR DESCRIPTION
Fixes #18 

I am hesitant to simply delete this code, but I cannot figure out what it was aiming at.  `NLM_F_MULTI` simply means there are more messages to come.